### PR TITLE
Stream search API with track=#HASHTAG returns "401 Unauthorized"

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -311,13 +311,13 @@ module Twitter
       @options[:params].merge( :track => @options[:filters] ).each do |param, val|
         next if val.empty?
         val = val.join(",") if val.respond_to?(:join)
-        flat[escape(param)] = escape(val)
+        flat[param.to_s] = val.to_s
       end
       flat
     end
 
     def query
-      params.map{|pair| pair.join("=")}.sort.join("&")
+      params.map{|param, value| [escape(param), escape(value)].join("=")}.sort.join("&")
     end
 
     def escape str


### PR DESCRIPTION
OAuth uses HTTP method, URL and request parameters to generate signature. So Twitter::JSONStream and SimpleOAuth::Header use the same request parameters. But the current code doesn't use the same request parameters. So request to http://stream.twitter.com/1/statuses/filter.json with track=#HASH_TAG request parameter and OAuth gets "401 Unauthorized".

Twitter::JSONStream#params returns escaped parameters and passes it to SimpleOAuth::Header. And SimpleOAuth::Header also escaped passed parameters. This is the problem. Twitter::JSONStream should pass not escaped parameters SimpleOAuth::Header.

Here is a sample code:
  stream_options = {
    :oauth => { ... },
    :host => "stream.twitter.com",
    :path => "/1/statuses/filter.json",
    :method => "POST",
    :filters => "#twitter",
  }
  stream = Twitter::JSONStream.connect(stream_options) # this stream will get "401 Unauthorized"

FYI: Streaming API document: http://dev.twitter.com/pages/streaming_api_methods#statuses-filter
