### PR TITLE
Some changes I've made when work on my Twitter client TwiMeido

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -230,6 +230,7 @@ module Twitter
         @too_often_callback.call if @too_often_callback
       else
         receive_error("invalid status code: #{@code}.")
+        stop
       end
     end
 


### PR DESCRIPTION
- Provide a no_data callback for no data received in 90 secs
  According to Twitter User Stream API doc, we should reconnect automatically when no data received in 90 secs, this is OK since Twitter will push blank lines for connection keep alive. But the `EventMachine::Connection#reconnect` has issues explained in http://goo.gl/LfpnG, I workaround it by provide a `no_data` callback, and just re-create the User Stream connection in application level.
- Provide callbacks for HTTP 401 & HTTP 420\
  With `unauthorized` callback, we can do things like clear User's access token to avoid meaningless retry in the future, in application level.
- Should stop on unexpected errors
  It's meaningless to keep the connection when unexpected errors occurred.
