### PR TITLE
Fixed 401 error with OAuth and the `:content` option

### DIFF
--- a/examples/reader.rb
+++ b/examples/reader.rb
@@ -9,7 +9,11 @@ EventMachine::run {
     :path    => '/1/statuses/filter.json',
     :auth    => 'LOGIN:PASSWORD',
     :method  => 'POST',
-    :content => 'track=basketball,football,baseball,footy,soccer'
+    :params => {
+      :track => 'basketball,football,baseball,footy,soccer',
+      :locations => '-122.75,36.8,-121.75,37.8,-74,40,-73,41',
+      :follow => '12,13,15,16,20,87'
+    }
   )
     
   stream.each_item do |item|

--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -332,7 +332,7 @@ module Twitter
     end
 
     def escape str
-      CGI.escape(str.to_s)
+      URI.escape(str.to_s)
     end
   end
 end

--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -24,7 +24,6 @@ module Twitter
       :method         => 'GET',
       :path           => '/',
       :content_type   => "application/x-www-form-urlencoded",
-      :content        => '',
       :path           => '/1/statuses/filter.json',
       :host           => 'stream.twitter.com',
       :port           => 80,
@@ -34,7 +33,6 @@ module Twitter
       :proxy          => ENV['HTTP_PROXY'],
       :auth           => nil,
       :oauth          => {},
-      :filters        => [],
       :params         => {},
       :auto_reconnect => true
     }
@@ -73,6 +71,10 @@ module Twitter
       @immediate_reconnect = false
       @on_inited_callback = options.delete(:on_inited)
       @proxy = URI.parse(options[:proxy]) if options[:proxy]
+
+      if filter = @options.delete(:filter)
+        @options[:params][:track] = filter.join(",")
+      end
     end
 
     def each_item &block
@@ -224,7 +226,7 @@ module Twitter
         request_uri = "#{uri_base}:#{@options[:port]}#{request_uri}"
       end
 
-      content = @options[:content]
+      content = ''
 
       unless (q = query).empty?
         if @options[:method].to_s.upcase == 'GET'
@@ -322,13 +324,7 @@ module Twitter
     # Normalized query hash of escaped string keys and escaped string values
     # nil values are skipped
     def params
-      flat = {}
-      @options[:params].merge( :track => @options[:filters] ).each do |param, val|
-        next if val.to_s.empty? || (val.respond_to?(:empty?) && val.empty?)
-        val = val.join(",") if val.respond_to?(:join)
-        flat[param.to_s] = val.to_s
-      end
-      flat
+      @options[:params]
     end
 
     def query
@@ -336,7 +332,7 @@ module Twitter
     end
 
     def escape str
-      URI.escape(str.to_s, /[^a-zA-Z0-9\-\.\_\~]/)
+      CGI.escape(str.to_s)
     end
   end
 end


### PR DESCRIPTION
The reader example fails with OAuth authentication.

The problem is the `:content` option and OAuth signature generation.  The OAuth library must know all the parameters in the request to generate a valid signature, and the `:content` option makes this difficult.  The gem could try to parse the `:content` option into params, but this seems unnecessary.

The attached pull request removes the `:content` option in favor of `:params`.
