### PR TITLE
Incorrect OAuth signature for GET's with params

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -248,7 +248,7 @@ module Twitter
       if @proxy && @proxy.user
         data << "Proxy-Authorization: Basic " + ["#{@proxy.user}:#{@proxy.password}"].pack('m').delete("\r\n")
       end
-      if @options[:method] == 'POST'
+      if ['POST', 'PUT'].include?(@options[:method])
         data << "Content-type: #{@options[:content_type]}"
         data << "Content-length: #{content.length}"
       end
@@ -311,7 +311,9 @@ module Twitter
         :token_secret => @options[:oauth][:access_secret]
       }
 
-      SimpleOAuth::Header.new(@options[:method], uri, params, oauth)
+      data = ['POST', 'PUT'].include?(@options[:method]) ? params : {}
+
+      SimpleOAuth::Header.new(@options[:method], uri, data, oauth)
     end
 
     # Scheme (https if ssl, http otherwise) and host part of URL


### PR DESCRIPTION
HTTP GET's weren't working for me using OAuth when I had params. This is because the OAuth signature was based on a request with a message body even though that body was never actually sent. This resulted in 401's from Twitter.

Also, I treat PUTs the same as POSTs similar to how OAuth::Consumer does.
