### PR TITLE
Reconnect with HTTPS fix: establish SSL connection also when reconnecting

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -60,7 +60,6 @@ module Twitter
       end
 
       connection = EventMachine.connect host, port, self, options
-      connection.start_tls if options[:ssl]
       connection
     end
 
@@ -122,6 +121,7 @@ module Twitter
     end
 
     def connection_completed
+      start_tls if @options[:ssl]
       send_request
     end
 

--- a/spec/twitter/json_stream_spec.rb
+++ b/spec/twitter/json_stream_spec.rb
@@ -69,6 +69,13 @@ describe JSONStream do
       stream = JSONStream.connect(:proxy => "http://my-proxy:8080") {}
     end
 
+    it "should not trigger SSL until connection is established" do
+      connection = stub('connection')
+      EM.should_receive(:connect).and_return(connection)
+      stream = JSONStream.connect(:ssl => true)
+      stream.should == connection
+    end
+
   end
 
   context "on valid stream" do
@@ -195,6 +202,12 @@ describe JSONStream do
     it "should not reconnect on inactivity when not configured to auto reconnect" do
       connect_stream(:stop_in => 1.5, :auto_reconnect => false) do
         stream.should_receive(:reconnect).never
+      end
+    end
+
+    it "should reconnect with SSL if enabled" do
+      connect_stream :ssl => true do
+        stream.should_receive(:start_tls).twice
       end
     end
 


### PR DESCRIPTION
This change is very small, it has tests, and fixes a low-level bug where reconnecting to Twitter failed as the appropriate HTTPS handshake was only made in the initial connection. Now HTTPS handshake is done with all established connections to Twitter.

Fixes #22
