### PR TITLE
closes #28 on voloko/twitter-stream by re-raising exceptions once handled

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -211,7 +211,7 @@ module Twitter
       rescue Exception => e
         receive_error("#{e.class}: " + [e.message, e.backtrace].flatten.join("\n\t"))
         close_connection
-        return
+        raise
       end
     end
 

--- a/spec/twitter/json_stream_spec.rb
+++ b/spec/twitter/json_stream_spec.rb
@@ -134,6 +134,14 @@ describe JSONStream do
       end
     end
 
+    it "should notify exceptions when delivering items" do
+      expect do
+        connect_stream :ssl => false do
+          stream.each_item { |item| raise RuntimeError, 'error message' }
+        end
+      end.to raise_error RuntimeError, 'error message'
+    end
+
     it "should send correct user agent" do
       connect_stream
     end


### PR DESCRIPTION
We have been bitten by this exception swallowing pretty badly last week. We lost a huge amount of time due our inability to track errors (we weren't even using this gem but other gem that actually does).

Added a spec to verify that if anything goes wrong while delivering items, the actual exception is popped after handling the connection instead of just returning.
