### PR TITLE
Update simple_oauth dependency

### DIFF
--- a/twitter-stream.gemspec
+++ b/twitter-stream.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.markdown", "LICENSE"]
 
   s.add_runtime_dependency('eventmachine', ">= 0.12.8")
-  s.add_runtime_dependency('simple_oauth', '~> 0.1.4')
+  s.add_runtime_dependency('simple_oauth', '~> 0.2.0')
   s.add_runtime_dependency('http_parser.rb', '~> 0.5.1')
   s.add_development_dependency('rspec', "~> 2.5.0")
 


### PR DESCRIPTION
The twitter gem has been requiring simple_oauth ~> 0.2.0 for a long
time now, upgrading twitter-stream so that both can be used in the same
project.
