### PR TITLE
Fix duplicate key(:path) specified in DEFAULT_OPTIONS

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -24,7 +24,6 @@ module Twitter
 
     DEFAULT_OPTIONS = {
       :method         => 'GET',
-      :path           => '/',
       :content_type   => "application/x-www-form-urlencoded",
       :content        => '',
       :path           => '/1/statuses/filter.json',


### PR DESCRIPTION
Fixed same key(:path) specified in DEFAULT_OPTIONS.

Following warnings is displayed in Ruby-2.2.0
```shell
/path/to/lib/twitter-stream/lib/twitter/json_stream.rb:27: warning: duplicated key at line 30 ignored: :path
```