### PR TITLE
Bump http_parser.rb version to 0.6.0

### DIFF
--- a/twitter-stream.gemspec
+++ b/twitter-stream.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('eventmachine', ">= 0.12.8")
   s.add_runtime_dependency('simple_oauth', '~> 0.2.0')
-  s.add_runtime_dependency('http_parser.rb', '~> 0.5.1')
+  s.add_runtime_dependency('http_parser.rb', '~> 0.6.0')
   s.add_development_dependency('rspec', "~> 2.5.0")
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
[Huginn](https://github.com/cantino/huginn) uses a few gems that require version `0.6.0` (twitter, em-http-request, em-websocket). We have been running on our own fork of `twitter_stream` with that version for some time, thus I am pretty sure it will not cause any issues.
