### PR TITLE
Upgrade eventmachine to 1.0.7 and adapt to new BufferedTokenizer api

### DIFF
--- a/lib/twitter/json_stream.rb
+++ b/lib/twitter/json_stream.rb
@@ -6,8 +6,6 @@ require 'http/parser'
 
 module Twitter
   class JSONStream < EventMachine::Connection
-    MAX_LINE_LENGTH = 1024*1024
-
     # network failure reconnections
     NF_RECONNECT_START = 0.25
     NF_RECONNECT_ADD   = 0.25
@@ -115,7 +113,7 @@ module Twitter
     end
 
     def unbind
-      if @state == :stream && !@buffer.empty?
+      if @state == :stream
         parse_stream_line(@buffer.flush)
       end
       schedule_reconnect if @options[:auto_reconnect] && !@gracefully_closed
@@ -202,7 +200,7 @@ module Twitter
       @code    = 0
       @headers = {}
       @state   = :init
-      @buffer  = BufferedTokenizer.new("\r", MAX_LINE_LENGTH)
+      @buffer  = BufferedTokenizer.new("\r")
       @stream  = ''
 
       @parser  = Http::Parser.new

--- a/twitter-stream.gemspec
+++ b/twitter-stream.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = ["README.markdown", "LICENSE"]
 
-  s.add_runtime_dependency('eventmachine', ">= 0.12.8")
+  s.add_runtime_dependency('eventmachine', "~> 1.0.7")
   s.add_runtime_dependency('simple_oauth', '~> 0.2.0')
   s.add_runtime_dependency('http_parser.rb', '~> 0.5.1')
   s.add_development_dependency('rspec', "~> 2.5.0")


### PR DESCRIPTION
Eventmachine 1.0.7 is needed for ruby 2.2 support.
